### PR TITLE
Enable global port listening

### DIFF
--- a/jobs/otel-collector-windows/spec
+++ b/jobs/otel-collector-windows/spec
@@ -16,6 +16,9 @@ properties:
   enabled:
     description: "Enable OTel Collector"
     default: true
+  ingress.grpc.internal_only:
+    description: "Only allow listening on local VM to receive OTLP over gRPC"
+    default: true
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
     default: 9100

--- a/jobs/otel-collector-windows/spec
+++ b/jobs/otel-collector-windows/spec
@@ -16,8 +16,8 @@ properties:
   enabled:
     description: "Enable OTel Collector"
     default: true
-  ingress.grpc.internal_only:
-    description: "Only allow listening on local VM to receive OTLP over gRPC"
+  ingress.grpc.local_only:
+    description: "Allow only local VM listening to receive OTLP over gRPC"
     default: true
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"

--- a/jobs/otel-collector-windows/spec
+++ b/jobs/otel-collector-windows/spec
@@ -16,9 +16,9 @@ properties:
   enabled:
     description: "Enable OTel Collector"
     default: true
-  ingress.grpc.local_only:
-    description: "Allow only local VM listening to receive OTLP over gRPC"
-    default: true
+  ingress.grpc.listen_address:
+    description: "Address the collector is listening on to receive OTLP over gRPC"
+    default: 127.0.0.1
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
     default: 9100

--- a/jobs/otel-collector-windows/templates/config.yml.erb
+++ b/jobs/otel-collector-windows/templates/config.yml.erb
@@ -7,14 +7,12 @@ if metric_exporters.keys.any?{|k| k.include?('/cf-internal')}
   raise 'Metric exporters cannot be defined under cf-internal namespace'
 end
 
-local_listening = p('ingress.grpc.local_only')
-
 config = {
   "receivers"=> {
     "otlp"=>{
       "protocols"=>{
         "grpc"=>{
-          "endpoint"=>local_listening ? "127.0.0.1:#{p('ingress.grpc.port')}" : ":#{p('ingress.grpc.port')}",
+          "endpoint"=>"#{p('ingress.grpc.listen_address')}:#{p('ingress.grpc.port')}",
           "tls"=>{
             "client_ca_file"=>"/var/vcap/jobs/otel-collector-windows/config/certs/otel-collector-ca.crt",
              "cert_file"=>"/var/vcap/jobs/otel-collector-windows/config/certs/otel-collector.crt",

--- a/jobs/otel-collector-windows/templates/config.yml.erb
+++ b/jobs/otel-collector-windows/templates/config.yml.erb
@@ -7,12 +7,14 @@ if metric_exporters.keys.any?{|k| k.include?('/cf-internal')}
   raise 'Metric exporters cannot be defined under cf-internal namespace'
 end
 
+local_listening = p('ingress.grpc.local_only')
+
 config = {
   "receivers"=> {
     "otlp"=>{
       "protocols"=>{
         "grpc"=>{
-          "endpoint"=>"127.0.0.1:#{p('ingress.grpc.port')}",
+          "endpoint"=>local_listening ? "127.0.0.1:#{p('ingress.grpc.port')}" : ":#{p('ingress.grpc.port')}",
           "tls"=>{
             "client_ca_file"=>"/var/vcap/jobs/otel-collector-windows/config/certs/otel-collector-ca.crt",
              "cert_file"=>"/var/vcap/jobs/otel-collector-windows/config/certs/otel-collector.crt",

--- a/jobs/otel-collector/spec
+++ b/jobs/otel-collector/spec
@@ -17,6 +17,9 @@ properties:
   enabled:
     description: "Enable OTel Collector"
     default: true
+  ingress.grpc.local_only:
+    description: "Allow only local VM listening to receive OTLP over gRPC"
+    default: true
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
     default: 9100

--- a/jobs/otel-collector/spec
+++ b/jobs/otel-collector/spec
@@ -17,9 +17,9 @@ properties:
   enabled:
     description: "Enable OTel Collector"
     default: true
-  ingress.grpc.local_only:
-    description: "Allow only local VM listening to receive OTLP over gRPC"
-    default: true
+  ingress.grpc.listen_address:
+    description: "Address the collector is listening on to receive OTLP over gRPC"
+    default: 127.0.0.1
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
     default: 9100

--- a/jobs/otel-collector/templates/config.yml.erb
+++ b/jobs/otel-collector/templates/config.yml.erb
@@ -10,14 +10,12 @@ if metric_exporters.any?{|k, v| k.start_with?('prometheus') && v['endpoint'] && 
   raise 'Cannot define prometheus exporter listening on port 8889 (reserved for BBS API port)'
 end
 
-local_listening = p('ingress.grpc.local_only')
-
 config = {
   "receivers"=> {
     "otlp"=>{
       "protocols"=>{
         "grpc"=>{
-          "endpoint"=>local_listening ? "127.0.0.1:#{p('ingress.grpc.port')}" : ":#{p('ingress.grpc.port')}",
+          "endpoint"=>"#{p('ingress.grpc.listen_address')}:#{p('ingress.grpc.port')}",
           "tls"=>{
             "client_ca_file"=>"/var/vcap/jobs/otel-collector/config/certs/otel-collector-ca.crt",
              "cert_file"=>"/var/vcap/jobs/otel-collector/config/certs/otel-collector.crt",

--- a/jobs/otel-collector/templates/config.yml.erb
+++ b/jobs/otel-collector/templates/config.yml.erb
@@ -10,12 +10,14 @@ if metric_exporters.any?{|k, v| k.start_with?('prometheus') && v['endpoint'] && 
   raise 'Cannot define prometheus exporter listening on port 8889 (reserved for BBS API port)'
 end
 
+local_listening = p('ingress.grpc.local_only')
+
 config = {
   "receivers"=> {
     "otlp"=>{
       "protocols"=>{
         "grpc"=>{
-          "endpoint"=>"127.0.0.1:#{p('ingress.grpc.port')}",
+          "endpoint"=>local_listening ? "127.0.0.1:#{p('ingress.grpc.port')}" : ":#{p('ingress.grpc.port')}",
           "tls"=>{
             "client_ca_file"=>"/var/vcap/jobs/otel-collector/config/certs/otel-collector-ca.crt",
              "cert_file"=>"/var/vcap/jobs/otel-collector/config/certs/otel-collector.crt",

--- a/spec/support/shared_examples_for_otel_collector.rb
+++ b/spec/support/shared_examples_for_otel_collector.rb
@@ -46,6 +46,21 @@ shared_examples_for 'common config.yml' do
           })
         end
 
+        context 'when ingress.grpc.listen_address is set to empty' do
+          let(:properties) { {'ingress' => {'grpc' => {'listen_address' => "", 'port' => 1234}}} }
+
+          it 'has an endpoint without an address' do
+            expect(otlpreceiver['protocols']['grpc']['endpoint']).to eq(':1234')
+          end
+        end
+
+        context 'when ingress.grpc.listen_address is defines' do
+          let(:properties) { {'ingress' => {'grpc' => {'listen_address' => "10.0.0.4", 'port' => 1234}}} }
+
+          it 'has an endpoint without an address' do
+            expect(otlpreceiver['protocols']['grpc']['endpoint']).to eq('10.0.0.4:1234')
+          end
+        end
         context 'when ingress.grpc.port is set' do
           let(:properties) { {'ingress' => {'grpc' => {'port' => 1234}}} }
 


### PR DESCRIPTION
Add a property that enables the ability for external VMs to write to the Otel ingress porr