### PR TITLE
Add trace exporters

### DIFF
--- a/jobs/otel-collector-windows/spec
+++ b/jobs/otel-collector-windows/spec
@@ -19,6 +19,9 @@ properties:
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
     default: 9100
+  ingress.grpc.address:
+    description: "Address to listen on to receive OTLP over gRPC"
+    default: 127.0.0.1
   ingress.grpc.tls.ca_cert:
     description: "CA root required for key/cert verification in gRPC ingress"
   ingress.grpc.tls.cert:
@@ -38,4 +41,12 @@ properties:
       otlp:
         endpoint: otelcol:4317
       otlp/2:
+        endpoint: otelcol:4318
+  trace_exporters:
+    description: "Exporter configuration for aggregate trace egress"
+    default: {}
+    example: |
+      otlp/trace:
+        endpoint: otelcol:4317
+      otlp/trace2:
         endpoint: otelcol:4318

--- a/jobs/otel-collector-windows/templates/config.yml.erb
+++ b/jobs/otel-collector-windows/templates/config.yml.erb
@@ -3,8 +3,22 @@ metric_exporters = p('metric_exporters')
 unless metric_exporters.respond_to?(:keys)
   metric_exporters = YAML::load(metric_exporters)
 end
-if metric_exporters.keys.any?{|k| k.include?('/cf-internal')}
-  raise 'Metric exporters cannot be defined under cf-internal namespace'
+
+trace_exporters = p('trace_exporters')
+unless trace_exporters.respond_to?(:keys)
+  trace_exporters = YAML::load(trace_exporters)
+end
+
+unless (trace_exporters.keys-metric_exporters.keys) == trace_exporters.keys
+  raise "Exporter names must be unique"
+end
+
+if (metric_exporters.keys + trace_exporters.keys).any?{|k| k.include?('/cf-internal')}
+  raise 'Exporters cannot be defined under cf-internal namespace'
+end
+
+if metric_exporters.any?{|k, v| k.start_with?('prometheus') && v['endpoint'] && v['endpoint'].end_with?(':8889')}
+  raise 'Cannot define prometheus exporter listening on port 8889 (reserved for BBS API port)'
 end
 
 config = {
@@ -12,7 +26,7 @@ config = {
     "otlp"=>{
       "protocols"=>{
         "grpc"=>{
-          "endpoint"=>"127.0.0.1:#{p('ingress.grpc.port')}",
+          "endpoint"=>"#{p('ingress.grpc.address')}:#{p('ingress.grpc.port')}",
           "tls"=>{
             "client_ca_file"=>"/var/vcap/jobs/otel-collector-windows/config/certs/otel-collector-ca.crt",
              "cert_file"=>"/var/vcap/jobs/otel-collector-windows/config/certs/otel-collector.crt",
@@ -23,7 +37,7 @@ config = {
       }
     }
   },
-  "exporters"=>metric_exporters,
+  "exporters"=>metric_exporters.merge(trace_exporters),
   "service"=>{
     "telemetry"=>{
       "metrics"=>{
@@ -31,9 +45,17 @@ config = {
         "address"=>"127.0.0.1:#{p('telemetry.metrics.port')}"
       }
     },
-    "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}}
+    "pipelines"=>{}
   }
 }
+
+if metric_exporters.any?
+  config['service']['pipelines']['metrics'] = {"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}
+end
+
+if trace_exporters.any?
+  config['service']['pipelines']['traces'] = {"receivers"=>["otlp"], "exporters"=>trace_exporters.keys}
+end
 
 YAML::dump(config)
 %>

--- a/jobs/otel-collector/spec
+++ b/jobs/otel-collector/spec
@@ -17,6 +17,9 @@ properties:
   enabled:
     description: "Enable OTel Collector"
     default: true
+  ingress.grpc.address:
+    description: "Address to listen on to receive OTLP over gRPC"
+    default: 127.0.0.1
   ingress.grpc.port:
     description: "Port the collector is listening on to receive OTLP over gRPC"
     default: 9100
@@ -39,4 +42,12 @@ properties:
       otlp:
         endpoint: otelcol:4317
       otlp/2:
+        endpoint: otelcol:4318
+  trace_exporters:
+    description: "Exporter configuration for aggregate trace egress"
+    default: {}
+    example: |
+      otlp/trace:
+        endpoint: otelcol:4317
+      otlp/trace2:
         endpoint: otelcol:4318

--- a/jobs/otel-collector/templates/config.yml.erb
+++ b/jobs/otel-collector/templates/config.yml.erb
@@ -3,9 +3,20 @@ metric_exporters = p('metric_exporters')
 unless metric_exporters.respond_to?(:keys)
   metric_exporters = YAML::load(metric_exporters)
 end
-if metric_exporters.keys.any?{|k| k.include?('/cf-internal')}
-  raise 'Metric exporters cannot be defined under cf-internal namespace'
+
+trace_exporters = p('trace_exporters')
+unless trace_exporters.respond_to?(:keys)
+  trace_exporters = YAML::load(trace_exporters)
 end
+
+unless (trace_exporters.keys-metric_exporters.keys) == trace_exporters.keys
+  raise "Exporter names must be unique"
+end
+
+if (metric_exporters.keys + trace_exporters.keys).any?{|k| k.include?('/cf-internal')}
+  raise 'Exporters cannot be defined under cf-internal namespace'
+end
+
 if metric_exporters.any?{|k, v| k.start_with?('prometheus') && v['endpoint'] && v['endpoint'].end_with?(':8889')}
   raise 'Cannot define prometheus exporter listening on port 8889 (reserved for BBS API port)'
 end
@@ -15,7 +26,7 @@ config = {
     "otlp"=>{
       "protocols"=>{
         "grpc"=>{
-          "endpoint"=>"127.0.0.1:#{p('ingress.grpc.port')}",
+          "endpoint"=>"#{p('ingress.grpc.address')}:#{p('ingress.grpc.port')}",
           "tls"=>{
             "client_ca_file"=>"/var/vcap/jobs/otel-collector/config/certs/otel-collector-ca.crt",
              "cert_file"=>"/var/vcap/jobs/otel-collector/config/certs/otel-collector.crt",
@@ -26,7 +37,7 @@ config = {
       }
     }
   },
-  "exporters"=>metric_exporters,
+  "exporters"=>metric_exporters.merge(trace_exporters),
   "service"=>{
     "telemetry"=>{
       "metrics"=>{
@@ -34,9 +45,17 @@ config = {
         "address"=>"127.0.0.1:#{p('telemetry.metrics.port')}"
       }
     },
-    "pipelines"=>{"metrics"=>{"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}}
+    "pipelines"=>{}
   }
 }
+
+if metric_exporters.any?
+  config['service']['pipelines']['metrics'] = {"receivers"=>["otlp"], "exporters"=>metric_exporters.keys}
+end
+
+if trace_exporters.any?
+  config['service']['pipelines']['traces'] = {"receivers"=>["otlp"], "exporters"=>trace_exporters.keys}
+end
 
 YAML::dump(config)
 %>

--- a/spec/jobs/otel-collector-windows_spec.rb
+++ b/spec/jobs/otel-collector-windows_spec.rb
@@ -2,12 +2,37 @@
 
 require 'rspec'
 require 'bosh/template/test'
-require 'support/shared_examples_for_otel_collector.rb'
+require 'support/shared_examples_for_otel_collector'
 
 describe 'otel-collector-windows' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }
+  let(:release_dir) { File.join(File.dirname(__FILE__), '../..') }
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(release_dir) }
   let(:job) { release.job('otel-collector-windows') }
   let(:config_path) { '/var/vcap/jobs/otel-collector-windows/config' }
 
   it_behaves_like 'common config.yml'
+
+  describe 'spec' do
+    it 'has only the specified differences from the linux spec' do
+      windows_spec = YAML.load(File.read(File.join(release_dir, 'jobs', 'otel-collector-windows', 'spec')))
+      linux_spec = YAML.load(File.read(File.join(release_dir, 'jobs', 'otel-collector', 'spec')))
+
+      windows_spec['name'] = 'otel-collector'
+      windows_spec['packages'] = ['otel-collector']
+      windows_spec['templates'].merge!({ 'bpm.yml.erb' => 'config/bpm.yml' })
+
+      expect(windows_spec).to eq(linux_spec)
+    end
+  end
+
+  describe 'config.yml' do
+    it 'has only the specified differences from the linux config' do
+      windows_config = File.read(File.join(release_dir, 'jobs', 'otel-collector-windows', 'templates', 'config.yml.erb'))
+      linux_config = File.read(File.join(release_dir, 'jobs', 'otel-collector', 'templates', 'config.yml.erb'))
+
+      windows_config.gsub!('/var/vcap/jobs/otel-collector-windows/', '/var/vcap/jobs/otel-collector/')
+
+      expect(windows_config).to eq(linux_config)
+    end
+  end
 end

--- a/spec/jobs/otel-collector_spec.rb
+++ b/spec/jobs/otel-collector_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rspec'
 require 'bosh/template/test'
-require 'support/shared_examples_for_otel_collector.rb'
+require 'support/shared_examples_for_otel_collector'
 
 describe 'otel-collector' do
   let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }

--- a/spec/support/shared_examples_for_otel_collector.rb
+++ b/spec/support/shared_examples_for_otel_collector.rb
@@ -7,50 +7,149 @@ require 'yaml'
 shared_examples_for 'common config.yml' do
   describe 'config/config.yml' do
     let(:template) { job.template('config/config.yml') }
-    let(:properties) {
+    let(:trace_exporters) { { 'otlp/traces' => { 'endpoint' => 'otelcol:4317' } } }
+    let(:metric_exporters) do
       {
-        'metric_exporters' => {
-          'otlp' => {'endpoint' => 'otelcol:4317'},
-          'prometheus/tls' => {
-            'endpoint' => '1.2.3.4:1234',
-            'metric_expiration' => '60m'
-          }
+        'otlp' => { 'endpoint' => 'otelcol:4317' },
+        'prometheus/tls' => {
+          'endpoint' => '1.2.3.4:1234',
+          'metric_expiration' => '60m'
         }
       }
-    }
+    end
+    let(:properties) do
+      {
+        'metric_exporters' => metric_exporters,
+        'trace_exporters' => trace_exporters
+      }
+    end
     let(:rendered) { YAML.load(template.render(properties)) }
 
+    describe 'exporters' do
+      let(:exporters) { rendered['exporters'] }
+
+      it 'has the right number of exporters' do
+        expect(exporters.count).to eq(3)
+      end
+
+      context 'when an exporter has a name collision' do
+        let(:trace_exporters) { { 'otlp' => { 'endpoint' => 'otelcol:4317' } } }
+        it 'raises an error' do
+          expect { rendered }.to raise_error(/Exporter names must be unique/)
+        end
+      end
+
+      describe 'trace exporters' do
+        it 'puts the trace exporters in the traces pipeline' do
+          expect(rendered['service']['pipelines']['traces']).to eq({ 'exporters' => ['otlp/traces'], 'receivers' => ['otlp'] })
+        end
+
+        context 'when exporters is a string and not a hash' do
+          let(:trace_exporters) { "{otlp/traces: {endpoint: 'otelcol:4317'}}" }
+          it 'parses it as YAML' do
+            expect(rendered['service']['pipelines']['traces']).to eq({ 'exporters' => ['otlp/traces'], 'receivers' => ['otlp'] })
+          end
+        end
+
+        context 'when an exporter uses the reserved namespace' do
+          let(:trace_exporters) { { 'otlp/cf-internal-foo' => { 'endpoint' => 'otelcol:4317' } } }
+          it 'raises an error' do
+            expect { rendered }.to raise_error(/Exporters cannot be defined under cf-internal namespace/)
+          end
+        end
+
+        context 'when trace exporters is empty' do
+          let(:trace_exporters) { {} }
+          it 'does not create a trace pipeline, which would cause otel-collector to error' do
+            expect(rendered['service']['pipelines']['traces']).to be_nil
+          end
+        end
+      end
+
+      describe 'metric exporters' do
+        it 'puts the metric exporters in the metrics pipeline' do
+          expect(rendered['service']['pipelines']['metrics']).to eq({ 'exporters' => ['otlp', 'prometheus/tls'], 'receivers' => ['otlp'] })
+        end
+
+        context 'when exporters is a string and not a hash' do
+          let(:metric_exporters) { "{otlp/metrics: {endpoint: 'otelcol:4317'}}" }
+          it 'parses it as YAML' do
+            expect(rendered['service']['pipelines']['metrics']).to eq({ 'exporters' => ['otlp/metrics'], 'receivers' => ['otlp'] })
+          end
+        end
+
+        context 'when there is a prometheus exporter listening on 8889' do
+          let(:metric_exporters) do
+            {
+              'prometheus/tls' => {
+                'endpoint' => '1.2.3.4:8889',
+                'metric_expiration' => '60m'
+              }
+            }
+          end
+
+          it 'raises an error' do
+            expect { rendered }.to raise_error(/Cannot define prometheus exporter listening on port 8889/)
+          end
+        end
+
+        context 'when an exporter uses the reserved namespace' do
+          let(:metric_exporters) { { 'otlp/cf-internal-foo' => { 'endpoint' => 'otelcol:4317' } } }
+          it 'raises an error' do
+            expect { rendered }.to raise_error(/Exporters cannot be defined under cf-internal namespace/)
+          end
+        end
+
+        context 'when metric exporters is empty' do
+          let(:metric_exporters) { {} }
+          it 'does not create a metric pipeline, which would cause otel-collector to error' do
+            expect(rendered['service']['pipelines']['metrics']).to be_nil
+          end
+        end
+      end
+    end
+
     context 'receivers' do
-      let(:receivers) { rendered["receivers"] }
+      let(:receivers) { rendered['receivers'] }
 
       it 'only has one receiver' do
         expect(receivers.count).to eq(1)
       end
 
       context 'otlpreceiver' do
-        let(:otlpreceiver) { rendered["receivers"]['otlp'] }
+        let(:otlpreceiver) { rendered['receivers']['otlp'] }
 
         it 'is configured by default' do
-          expect(otlpreceiver).to eq({
-            'protocols' => {
-              'grpc' => {
-                'endpoint' => '127.0.0.1:9100',
-                'tls' => {
-                  'client_ca_file' => "#{config_path}/certs/otel-collector-ca.crt",
-                  'cert_file' => "#{config_path}/certs/otel-collector.crt",
-                  'key_file' => "#{config_path}/certs/otel-collector.key",
-                  'min_version' => '1.3'
+          expect(otlpreceiver).to eq(
+            {
+              'protocols' => {
+                'grpc' => {
+                  'endpoint' => '127.0.0.1:9100',
+                  'tls' => {
+                    'client_ca_file' => "#{config_path}/certs/otel-collector-ca.crt",
+                    'cert_file' => "#{config_path}/certs/otel-collector.crt",
+                    'key_file' => "#{config_path}/certs/otel-collector.key",
+                    'min_version' => '1.3'
+                  }
                 }
               }
             }
-          })
+          )
         end
 
         context 'when ingress.grpc.port is set' do
-          let(:properties) { {'ingress' => {'grpc' => {'port' => 1234}}} }
+          let(:properties) { { 'ingress' => { 'grpc' => { 'port' => 1234 } } } }
 
           it 'has an endpoint with that port' do
             expect(otlpreceiver['protocols']['grpc']['endpoint']).to eq('127.0.0.1:1234')
+          end
+        end
+
+        context 'when ingress.grpc.listen_address is set' do
+          let(:properties) { { 'ingress' => { 'grpc' => { 'address' => '0.0.0.0' } } } }
+
+          it 'has an endpoint with that address' do
+            expect(otlpreceiver['protocols']['grpc']['endpoint']).to eq('0.0.0.0:9100')
           end
         end
       end


### PR DESCRIPTION
Doing this in advance of adding support for converting HttpStartStop events to Otel Traces in Forwarder Agent.

also took care of a few things:
- add ability to set listen address as discussed in https://github.com/cloudfoundry/otel-collector-release/pull/12
- backfill a bunch of template tests
- add test to ensure windows and linux spec and config.yml stay in sync

