### PR TITLE
feat: Add scripts for testing

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,4 +1,4 @@
-name: 'Template specs'
+name: scripts
 
 on:
   push:
@@ -9,13 +9,12 @@ on:
     - main
 
 jobs:
-  test:
+  spec-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2'
+        ruby-version: '2.7'
         bundler-cache: true
-    - name: 'Run specs'
-      run: bundle exec rspec
+    - run: ./scripts/subtests/spec-test

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 group :development, :test do
-  gem 'bosh-template'
+  gem 'bosh-template', '2.2.1'
   gem 'rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bosh-template (2.4.0)
+    bosh-template (2.2.1)
       semi_semantic (~> 1.2.0)
     diff-lcs (1.5.1)
     rspec (3.13.0)
@@ -23,8 +23,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bosh-template
+  bosh-template (= 2.2.1)
   rspec
 
-BUNDLED WITH
-   2.4.10

--- a/scripts/subtests/spec-test
+++ b/scripts/subtests/spec-test
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eux
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+pushd "${SCRIPT_DIR}/../.." > /dev/null
+    bundle exec rspec
+popd > /dev/null
+

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eux
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+"${SCRIPT_DIR}/subtests/spec-test"
+


### PR DESCRIPTION
- Adds scripts for testing.
- Uses those scripts in gh actions.
- Downgrades bosh-template version to match ruby 2.7, which is what the cf-d-c-t image uses for now.