### PR TITLE
feat(otel-collector): Add memory limit

### DIFF
--- a/jobs/otel-collector/spec
+++ b/jobs/otel-collector/spec
@@ -25,6 +25,9 @@ properties:
     description: "Processors allowed for use in otel-collector config. Must be a subset of list included in otel-collector builder config. Empty list means allow all possible."
     default: []
     example: ['batch']
+  limits.memory:
+    description: "Memory limit to apply to this process. It is formatted as a number and then a single character for units."
+    example: 1G
   config:
     description: "Collector configuration"
     default: {}

--- a/jobs/otel-collector/templates/bpm.yml.erb
+++ b/jobs/otel-collector/templates/bpm.yml.erb
@@ -1,4 +1,15 @@
-processes:
-- name: otel-collector
-  executable: /var/vcap/packages/otel-collector/otel-collector
-  args: ["--config", "/var/vcap/jobs/otel-collector/config/config.yml"]
+<%
+    process = {
+      'name' => 'otel-collector',
+      'executable' => '/var/vcap/packages/otel-collector/otel-collector',
+      'args' => ['--config', '/var/vcap/jobs/otel-collector/config/config.yml']
+    }
+
+    if_p('limits.memory') {
+      process['limits'] = { 'memory' => p('limits.memory') }
+    }
+
+    bpm = { 'processes' => [process] }
+%>
+
+<%= YAML.dump(bpm) %>

--- a/spec/jobs/otel-collector_spec.rb
+++ b/spec/jobs/otel-collector_spec.rb
@@ -11,4 +11,44 @@ describe 'otel-collector' do
   let(:config_path) { '/var/vcap/jobs/otel-collector/config' }
 
   it_behaves_like 'common config.yml'
+
+  describe 'config/bpm.yml' do
+    let(:template) { job.template('config/bpm.yml') }
+    let(:properties) { { 'limits' => { 'memory' => '1G' } } }
+    let(:rendered) { YAML.safe_load(template.render(properties)) }
+
+    describe 'limits' do
+      context 'when no limits are provided' do
+        before do
+          properties.delete('limits')
+        end
+
+        it 'is not set in bpm' do
+          expect(rendered['processes'][0].keys).to_not include 'limits'
+        end
+      end
+
+      describe 'memory' do
+        context 'when not provided' do
+          before do
+            properties['limits'].delete('memory')
+          end
+
+          it 'is not set in bpm' do
+            expect(rendered['processes'][0]).to_not include 'limits'
+          end
+        end
+
+        context 'when a valid memory limit is provided' do
+          before do
+            properties['limits']['memory'] = '1G'
+          end
+
+          it 'sets the bpm memory limit' do
+            expect(rendered['processes'][0]['limits']['memory']).to eq('1G')
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds the `limits.memory` property, which, if set, configures a hard memory limit on the otel-collector job via BPM.