### PR TITLE
feat: Add CPU limit

### DIFF
--- a/jobs/otel-collector-windows/monit
+++ b/jobs/otel-collector-windows/monit
@@ -1,18 +1,22 @@
-<%
+<%=
   process = {
     "name" => "otel-collector",
     "executable" => "/var/vcap/packages/otel-collector-windows/otel-collector.exe",
     "args" => ["--config", "/var/vcap/jobs/otel-collector-windows/config/config.yml"],
-    "env" => {"NO_WINDOWS_SERVICE" => "1"}
+    "env" => {
+      "NO_WINDOWS_SERVICE" => "1",
+      'GOMEMLIMIT'         => "#{(p('limits.memory_mib').to_i * 0.80).floor}MiB"
+    }
   }
 
-  memory_mib = p('limits.memory_mib')
-  process['env']['GOMEMLIMIT'] = "#{(memory_mib.to_i * 0.80).floor}MiB"
-
+  if_p('limits.cpu') do |cpu|
+    process['env']['GOMAXPROCS'] = p('limits.cpu').to_i
+  end
+  
   monit = { "processes" => [] }
   if p('enabled')
     monit["processes"] = [process]
   end
-%>
 
-<%= JSON.pretty_generate(monit) %>
+  JSON.pretty_generate(monit)
+%>

--- a/jobs/otel-collector-windows/spec
+++ b/jobs/otel-collector-windows/spec
@@ -19,6 +19,8 @@ properties:
   limits.memory_mib:
     description: "Memory limit to apply to this process, in mebibytes."
     default: 512
+  limits.cpu:
+    description: "Controls how many CPU cores this process can use simultaneously."
   config:
     description: "Collector configuration"
     default: {}

--- a/jobs/otel-collector/spec
+++ b/jobs/otel-collector/spec
@@ -28,6 +28,8 @@ properties:
   limits.memory_mib:
     description: "Memory limit to apply to this process, in mebibytes."
     default: 512
+  limits.cpu:
+    description: "Controls how many CPU cores this process can use simultaneously."
   config:
     description: "Collector configuration"
     default: {}

--- a/jobs/otel-collector/templates/bpm.yml.erb
+++ b/jobs/otel-collector/templates/bpm.yml.erb
@@ -1,15 +1,19 @@
-<%
-    process = {
-      'name' => 'otel-collector',
-      'executable' => '/var/vcap/packages/otel-collector/otel-collector',
-      'args' => ['--config', '/var/vcap/jobs/otel-collector/config/config.yml']
+<%=
+  bpm = {
+    'processes' => [
+        {
+          'name' => 'otel-collector',
+          'executable' => '/var/vcap/packages/otel-collector/otel-collector',
+          'args' => ['--config', '/var/vcap/jobs/otel-collector/config/config.yml'],
+          'env' => { 'GOMEMLIMIT' => "#{(p('limits.memory_mib').to_i * 0.80).floor}MiB" },
+          'limits' => { 'memory' => "#{p('limits.memory_mib')}MiB" }
+        }
+      ]
     }
 
-    memory_mib = p('limits.memory_mib')
-    process['limits'] = { 'memory' => "#{memory_mib}MiB" }
-    process['env'] = { 'GOMEMLIMIT' => "#{(memory_mib.to_i * 0.80).floor}MiB" }
-
-    bpm = { 'processes' => [process] }
+    if_p('limits.cpu') do |cpu|
+      bpm['processes'][0]['env']['GOMAXPROCS'] = cpu.to_i 
+    end
+    
+    YAML.dump(bpm) 
 %>
-
-<%= YAML.dump(bpm) %>

--- a/spec/jobs/otel-collector-windows_spec.rb
+++ b/spec/jobs/otel-collector-windows_spec.rb
@@ -66,6 +66,28 @@ describe 'otel-collector-windows' do
           end
         end
       end
+
+      describe 'cpu' do
+        context 'when not provided' do
+          before do
+            properties['limits'].delete('cpu')
+          end
+
+          it 'does not set GOMAXPROCS' do
+            expect(rendered['processes'][0]['env']).not_to have_key('GOMAXPROCS')
+          end
+        end
+
+        context 'when a custom cpu limit is provided' do
+          before do
+            properties['limits']['cpu'] = 2
+          end
+
+          it 'sets GOMAXPROCS' do
+            expect(rendered['processes'][0]['env']['GOMAXPROCS']).to eq(2)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/jobs/otel-collector_spec.rb
+++ b/spec/jobs/otel-collector_spec.rb
@@ -14,7 +14,7 @@ describe 'otel-collector' do
 
   describe 'config/bpm.yml' do
     let(:template) { job.template('config/bpm.yml') }
-    let(:properties) { { 'limits' => { 'memory_mib' => '512' } } }
+    let(:properties) { { 'limits' => { 'memory_mib' => '512', 'cpu' => '1' } } }
     let(:rendered) { YAML.safe_load(template.render(properties)) }
 
     describe 'limits' do
@@ -38,6 +38,28 @@ describe 'otel-collector' do
           it 'sets the bpm memory limit and GOMEMLIMIT' do
             expect(rendered['processes'][0]['limits']['memory']).to eq('1000MiB')
             expect(rendered['processes'][0]['env']['GOMEMLIMIT']).to eq('800MiB')
+          end
+        end
+      end
+
+      describe 'cpu' do
+        context 'when not provided' do
+          before do
+            properties['limits'].delete('cpu')
+          end
+
+          it 'does not set GOMAXPROCS' do
+            expect(rendered['processes'][0]['env']).not_to have_key('GOMAXPROCS')
+          end
+        end
+
+        context 'when a custom cpu limit is provided' do
+          before do
+            properties['limits']['cpu'] = 2
+          end
+
+          it 'sets GOMAXPROCS' do
+            expect(rendered['processes'][0]['env']['GOMAXPROCS']).to eq(2)
           end
         end
       end


### PR DESCRIPTION
Adds the `limits.cpu` property to the otel-collector and otel-collector-windows jobs. This property in turn configures `GOMAXPROCS` to control how many CPU cores otel-collector process can use simultaneously. By default, the value will be set to 1 core only.