### PR TITLE
tests: Bump ruby to 3.1

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3.1'
         bundler-cache: true
     - run: ./scripts/subtests/spec-test
   integration-test:

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 
 source 'https://rubygems.org'
 
-ruby '~> 2.7'
+ruby '~> 3.1'
 
 group :development, :test do
-  gem 'bosh-template', '2.2.1'
+  gem 'bosh-template'
   gem 'rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bosh-template (2.2.1)
+    bosh-template (2.4.0)
       semi_semantic (~> 1.2.0)
     diff-lcs (1.5.1)
     rspec (3.13.0)
@@ -23,9 +23,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bosh-template (= 2.2.1)
+  bosh-template
   rspec
 
 RUBY VERSION
-   ruby 2.7.8p225
+   ruby 3.1.6p260
 
+BUNDLED WITH
+   2.5.23


### PR DESCRIPTION
- Bumps required ruby version to ~3.1.
- Unpins bosh-template library.
- Updates the GH action runner to install ruby ~3.1.