### PR TITLE
tests: Bump dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
 #   schedule:
 #     interval: "weekly"
 
+- package-ecosystem: "gomod"
+  directory: "/src/integration"
+  schedule:
+    interval: "weekly"
+
 - package-ecosystem: "bundler"
   directory: "/"
   schedule:

--- a/src/integration/go.mod
+++ b/src/integration/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/otel-collector-release/src/integration
 
-go 1.22.0
+go 1.23.0
 
 require (
 	code.cloudfoundry.org/otel-collector-release/src/otel-collector v0.0.0


### PR DESCRIPTION
- Configures dependabot to watch the integration test deps.
- Bumps the minimum required version of Go for the integration tests to match the latest minimum required version of Go for ginkgo.