### PR TITLE
Update otel binary name and config erb

### DIFF
--- a/jobs/otel-collector-windows/templates/config.yml.erb
+++ b/jobs/otel-collector-windows/templates/config.yml.erb
@@ -147,7 +147,7 @@ end
 def expose_internal_telemetry
   config['service']['telemetry'] = {
     'metrics' => {
-      'address' => "127.0.0.1:#{p('telemetry.metrics.port')}",
+      'readers' => ['pull' => {'exporter' => {'prometheus' => {'host' => '127.0.0.1', 'port' => p("telemetry.metrics.port")}}}],
       'level' => p('telemetry.metrics.level')
     }
   }

--- a/jobs/otel-collector/templates/config.yml.erb
+++ b/jobs/otel-collector/templates/config.yml.erb
@@ -147,7 +147,7 @@ end
 def expose_internal_telemetry
   config['service']['telemetry'] = {
     'metrics' => {
-      'address' => "127.0.0.1:#{p('telemetry.metrics.port')}",
+      'readers' => ['pull' => {'exporter' => {'prometheus' => {'host' => '127.0.0.1', 'port' => p("telemetry.metrics.port")}}}],
       'level' => p('telemetry.metrics.level')
     }
   }

--- a/packages/golang-1.23-linux/spec.lock
+++ b/packages/golang-1.23-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.23-linux
-fingerprint: 0318ed53dd7c034bd98549c09ba9cb470ce90c50431ad61d51f355fa9afff2e8

--- a/packages/golang-1.23-windows/spec.lock
+++ b/packages/golang-1.23-windows/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.23-windows
-fingerprint: 0b625a1e557fd0b2ad12c13557c9fafca4f1b66cce23ca85909b58da0b367b9d

--- a/packages/golang-1.25-linux/spec.lock
+++ b/packages/golang-1.25-linux/spec.lock
@@ -1,0 +1,2 @@
+name: golang-1.25-linux
+fingerprint: f39b9add821126d4a840673be382775fb3e2030ea0143cfa8d52adb4eee8e21a

--- a/packages/golang-1.25-windows/spec.lock
+++ b/packages/golang-1.25-windows/spec.lock
@@ -1,0 +1,2 @@
+name: golang-1.25-windows
+fingerprint: 510f5862c19384a84665be6ce3e441f3dde45d3752ae4f64182d8127bac88f98

--- a/packages/otel-collector-windows/packaging
+++ b/packages/otel-collector-windows/packaging
@@ -1,5 +1,5 @@
 . ./exiter.ps1
-. C:\var\vcap\packages\golang-1.23-windows\bosh\compile.ps1
+. C:\var\vcap\packages\golang-1.25-windows\bosh\compile.ps1
 $env:CGO_ENABLED="0"
 
 $ErrorActionPreference = "Stop";

--- a/packages/otel-collector-windows/packaging
+++ b/packages/otel-collector-windows/packaging
@@ -17,6 +17,6 @@ Push-Location otel-collector-builder\
   }
 Pop-Location
 
-Copy-Item "otel-collector\cf-otel-collector" -Destination "${env:BOSH_INSTALL_TARGET}\otel-collector.exe"
+Copy-Item "otel-collector\otelcol-cf" -Destination "${env:BOSH_INSTALL_TARGET}\otel-collector.exe"
 
 Exit 0

--- a/packages/otel-collector-windows/spec
+++ b/packages/otel-collector-windows/spec
@@ -2,7 +2,7 @@
 name: otel-collector-windows
 
 dependencies:
-- golang-1.23-windows
+- golang-1.25-windows
 
 files:
 - exiter.ps1

--- a/packages/otel-collector/packaging
+++ b/packages/otel-collector/packaging
@@ -9,4 +9,4 @@ pushd otel-collector-builder
   go run go.opentelemetry.io/collector/cmd/builder --config=config.yaml --skip-generate --skip-get-modules
 popd
 
-cp "otel-collector/cf-otel-collector" "${BOSH_INSTALL_TARGET}/otel-collector"
+cp "otel-collector/otelcol-cf" "${BOSH_INSTALL_TARGET}/otel-collector"

--- a/packages/otel-collector/packaging
+++ b/packages/otel-collector/packaging
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -x
 
-source /var/vcap/packages/golang-1.23-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.25-linux/bosh/compile.env
 
 export CGO_ENABLED=0
 

--- a/packages/otel-collector/spec
+++ b/packages/otel-collector/spec
@@ -2,7 +2,7 @@
 name: otel-collector
 
 dependencies:
-- golang-1.23-linux
+- golang-1.25-linux
 
 files:
 - otel-collector-builder/**/*

--- a/spec/support/shared_examples_for_otel_collector.rb
+++ b/spec/support/shared_examples_for_otel_collector.rb
@@ -453,7 +453,8 @@ shared_examples_for 'common config.yml' do
 
     describe 'internal telemetry' do
       it 'exposes telemetry at the default port' do
-        expect(rendered['service']['telemetry']['metrics']['address']).to eq('127.0.0.1:14830')
+        expect(rendered['service']['telemetry']['metrics']['readers'][0]['pull']['exporter']['prometheus']['host']).to eq('127.0.0.1')
+        expect(rendered['service']['telemetry']['metrics']['readers'][0]['pull']['exporter']['prometheus']['port']).to eq(14830)
       end
       it 'provides basic level metrics by default' do
         expect(rendered['service']['telemetry']['metrics']['level']).to eq('basic')
@@ -462,7 +463,8 @@ shared_examples_for 'common config.yml' do
       context 'when the port is specified' do
         let(:properties) { { 'config' => config, 'telemetry' => { 'metrics' => { 'port' => 14_831 } } } }
         it 'exposes telemetry at the specified port' do
-          expect(rendered['service']['telemetry']['metrics']['address']).to eq('127.0.0.1:14831')
+          expect(rendered['service']['telemetry']['metrics']['readers'][0]['pull']['exporter']['prometheus']['host']).to eq('127.0.0.1')
+          expect(rendered['service']['telemetry']['metrics']['readers'][0]['pull']['exporter']['prometheus']['port']).to eq(14_831)
         end
       end
 

--- a/src/acceptance/go.mod
+++ b/src/acceptance/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/otel-collector-release/src/acceptance
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.25.1

--- a/src/integration/go.mod
+++ b/src/integration/go.mod
@@ -1,8 +1,6 @@
 module code.cloudfoundry.org/otel-collector-release/src/integration
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.0
 
 require (
 	code.cloudfoundry.org/otel-collector-release/src/otel-collector v0.0.0

--- a/src/otel-collector-builder/go.mod
+++ b/src/otel-collector-builder/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/otel-collector-release/src/otel-collector-builder
 
-go 1.24.0
+go 1.25.0
 
 require go.opentelemetry.io/collector/cmd/builder v0.132.0
 

--- a/src/otel-collector-builder/go.mod
+++ b/src/otel-collector-builder/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/otel-collector-release/src/otel-collector-builder
 
-go 1.23.0
+go 1.24.0
 
 require go.opentelemetry.io/collector/cmd/builder v0.132.0
 


### PR DESCRIPTION
Changes to accomodate opentelemetry update to build bosh release

1. The otel binary has been renamed to otel-cf
2. In otel config file, the service.telemetry.metrics.address is not long supported it has been replaced with service.telemetry.metrics.readers