### PR TITLE
Lock ruby 3.3

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.3'
         bundler-cache: true
     - run: ./scripts/subtests/spec-test
   integration-test:

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source 'https://rubygems.org'
 
+ruby '~> 3.3.0'
 
 group :development, :test do
   gem 'bosh-template'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,5 +26,8 @@ DEPENDENCIES
   bosh-template
   rspec
 
+RUBY VERSION
+   ruby 3.3.11p205
+
 BUNDLED WITH
    2.5.23


### PR DESCRIPTION
Fix regression of f25749ab1d99dbdbc85f6191801a0bc2a6ca53ff and pin newest ruby version that other bosh releases use.

I found out that haproxy-boshrelease and capi-release are using 3.3.